### PR TITLE
fix Restrict modules to specified networks #215

### DIFF
--- a/discord/interactions/addConfigCommand.ts
+++ b/discord/interactions/addConfigCommand.ts
@@ -143,13 +143,23 @@ const handleBackToModule = async (
   client: Client,
   restClient: REST
 ) => {
+  const config = ongoingConfigurationsCache[interaction.guildId!];
+  const selectedNetwork = config.network;
+
   const modulesOptions: SelectMenuComponentOptionData[] = [];
   for (const starkyModuleId in starkyModules) {
     const starkyModule = starkyModules[starkyModuleId];
-    modulesOptions.push({
-      label: starkyModule.name,
-      value: starkyModuleId,
-    });
+    // Filter modules based on network support
+    if (
+      starkyModule.networks &&
+      selectedNetwork &&
+      starkyModule.networks.includes(selectedNetwork)
+    ) {
+      modulesOptions.push({
+        label: starkyModule.name,
+        value: starkyModuleId,
+      });
+    }
   }
 
   const selectRow =
@@ -455,13 +465,17 @@ export const handleNetworkConfigCommand = async (
     components: [],
   });
 
+  // Filter modules based on selected network
   const modulesOptions: SelectMenuComponentOptionData[] = [];
   for (const starkyModuleId in starkyModules) {
     const starkyModule = starkyModules[starkyModuleId];
-    modulesOptions.push({
-      label: starkyModule.name,
-      value: starkyModuleId,
-    });
+    // Only include modules that support the selected network
+    if (starkyModule.networks && starkyModule.networks.includes(network)) {
+      modulesOptions.push({
+        label: starkyModule.name,
+        value: starkyModuleId,
+      });
+    }
   }
 
   const selectRow =

--- a/package-lock.json
+++ b/package-lock.json
@@ -2000,6 +2000,126 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.26.tgz",
+      "integrity": "sha512-U0adH5ryLfmTDkahLwG9sUQG2L0a9rYux8crQeC92rPhi3jGQEY47nByQHrVrt3prZigadwj/2HZ1LUUimuSbg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.26.tgz",
+      "integrity": "sha512-SINMl1I7UhfHGM7SoRiw0AbwnLEMUnJ/3XXVmhyptzriHbWvPPbbm0OEVG24uUKhuS1t0nvN/DBvm5kz6ZIqpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.26.tgz",
+      "integrity": "sha512-s6JaezoyJK2DxrwHWxLWtJKlqKqTdi/zaYigDXUJ/gmx/72CrzdVZfMvUc6VqnZ7YEvRijvYo+0o4Z9DencduA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.26.tgz",
+      "integrity": "sha512-FEXeUQi8/pLr/XI0hKbe0tgbLmHFRhgXOUiPScz2hk0hSmbGiU8aUqVslj/6C6KA38RzXnWoJXo4FMo6aBxjzg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.26.tgz",
+      "integrity": "sha512-BUsomaO4d2DuXhXhgQCVt2jjX4B4/Thts8nDoIruEJkhE5ifeQFtvW5c9JkdOtYvE5p2G0hcwQ0UbRaQmQwaVg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.26.tgz",
+      "integrity": "sha512-5auwsMVzT7wbB2CZXQxDctpWbdEnEW/e66DyXO1DcgHxIyhP06awu+rHKshZE+lPLIGiwtjo7bsyeuubewwxMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
+      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.26",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.26.tgz",
+      "integrity": "sha512-2rdB3T1/Gp7bv1eQTTm9d1Y1sv9UuJ2LAwOE0Pe2prHKe32UNscj7YS13fRB37d0GAiGNR+Y7ZcW8YjDI8Ns0w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@noble/ciphers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.0.tgz",
@@ -15505,126 +15625,6 @@
         "use-sync-external-store": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.26.tgz",
-      "integrity": "sha512-U0adH5ryLfmTDkahLwG9sUQG2L0a9rYux8crQeC92rPhi3jGQEY47nByQHrVrt3prZigadwj/2HZ1LUUimuSbg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.26.tgz",
-      "integrity": "sha512-SINMl1I7UhfHGM7SoRiw0AbwnLEMUnJ/3XXVmhyptzriHbWvPPbbm0OEVG24uUKhuS1t0nvN/DBvm5kz6ZIqpg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.26.tgz",
-      "integrity": "sha512-s6JaezoyJK2DxrwHWxLWtJKlqKqTdi/zaYigDXUJ/gmx/72CrzdVZfMvUc6VqnZ7YEvRijvYo+0o4Z9DencduA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.26.tgz",
-      "integrity": "sha512-FEXeUQi8/pLr/XI0hKbe0tgbLmHFRhgXOUiPScz2hk0hSmbGiU8aUqVslj/6C6KA38RzXnWoJXo4FMo6aBxjzg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.26.tgz",
-      "integrity": "sha512-BUsomaO4d2DuXhXhgQCVt2jjX4B4/Thts8nDoIruEJkhE5ifeQFtvW5c9JkdOtYvE5p2G0hcwQ0UbRaQmQwaVg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.26.tgz",
-      "integrity": "sha512-5auwsMVzT7wbB2CZXQxDctpWbdEnEW/e66DyXO1DcgHxIyhP06awu+rHKshZE+lPLIGiwtjo7bsyeuubewwxMw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
-      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.26.tgz",
-      "integrity": "sha512-2rdB3T1/Gp7bv1eQTTm9d1Y1sv9UuJ2LAwOE0Pe2prHKe32UNscj7YS13fRB37d0GAiGNR+Y7ZcW8YjDI8Ns0w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/starkyModules/erc721.ts
+++ b/starkyModules/erc721.ts
@@ -7,6 +7,7 @@ import { callContract } from "../utils/starknet/call";
 export const name = "ERC-721";
 export const refreshInCron = false;
 export const refreshOnTransfer = true;
+export const networks = ["mainnet", "sepolia", "ethereum-mainnet"];
 
 export const fields: StarkyModuleField[] = [
   {

--- a/starkyModules/erc721Metadata.ts
+++ b/starkyModules/erc721Metadata.ts
@@ -4,6 +4,7 @@ import { retrieveAssets } from "../utils/retrieveAsset";
 export const name = "ERC-721 Metadata";
 export const refreshInCron = false;
 export const refreshOnTransfer = true;
+export const networks = ["mainnet", "sepolia"];
 
 export const fields: StarkyModuleField[] = [
   {

--- a/starkyModules/erc721Metadata.ts
+++ b/starkyModules/erc721Metadata.ts
@@ -4,7 +4,7 @@ import { retrieveAssets } from "../utils/retrieveAsset";
 export const name = "ERC-721 Metadata";
 export const refreshInCron = false;
 export const refreshOnTransfer = true;
-export const networks = ["mainnet", "sepolia"];
+export const networks = ["mainnet", "sepolia", "ethereum-mainnet"];
 
 export const fields: StarkyModuleField[] = [
   {

--- a/starkyModules/walletDetector.ts
+++ b/starkyModules/walletDetector.ts
@@ -8,6 +8,7 @@ export const name = "Wallet detector (Argent only)";
 // Only refreshing when connecting the wallet or when using the /starky-refresh command
 export const refreshInCron = false;
 export const refreshOnTransfer = false;
+export const networks = ["mainnet", "sepolia"];
 
 // TODO => add field to ask for Argent or Braavos
 // we need to be able to validate config first

--- a/types/starkyModules.ts
+++ b/types/starkyModules.ts
@@ -20,6 +20,7 @@ export type StarkyModule = {
   shouldHaveRole: ShouldHaveRole;
   refreshInCron: boolean;
   refreshOnTransfer: boolean;
+  networks?: (StarknetNetworkName | string)[]; // Add this line to fix the TypeScript errors
 };
 
 export type StarkyModules = {

--- a/types/starkyModules.ts
+++ b/types/starkyModules.ts
@@ -20,7 +20,7 @@ export type StarkyModule = {
   shouldHaveRole: ShouldHaveRole;
   refreshInCron: boolean;
   refreshOnTransfer: boolean;
-  networks?: (NetworkName | string)[];
+  networks: NetworkName[];
 };
 
 export type StarkyModules = {

--- a/types/starkyModules.ts
+++ b/types/starkyModules.ts
@@ -20,7 +20,7 @@ export type StarkyModule = {
   shouldHaveRole: ShouldHaveRole;
   refreshInCron: boolean;
   refreshOnTransfer: boolean;
-  networks?: (StarknetNetworkName | string)[]; // Add this line to fix the TypeScript errors
+  networks?: (NetworkName | string)[];
 };
 
 export type StarkyModules = {


### PR DESCRIPTION
## 📌 Description

This PR implements network filtering for modules in `starkyModules` and updates the display logic in the Discord interaction handler based on the selected network.

## ✅ Changes Made

- Added a `networks` export to each module in `starkyModules`:
  - All modules except `ERC721` now export:
    ```ts
    export const networks = ["mainnet", "sepolia"];
    ```
  - The `ERC721` module exports:
    ```ts
    export const networks = ["mainnet", "sepolia", "ethereum-mainnet"];
    ```

- Updated the `handleModuleConfigCommand` function in `discord/interactions/addConfigCommand.ts` to:
  - Display only the modules whose `networks` array includes the selected network.

## 🧪 Testing

- Verified that modules are filtered correctly based on the selected network.
- Confirmed that the application builds and runs successfully.
- Ensured no existing functionality is broken after the changes.

## 🧹 Cleanup

- Code linted and organized.
- Unused variables and dead code removed if applicable.

## 📎 Related Issue

Close #215 
## 🏷️ Labels

- Change label to `ready for review` once submitted.
