### PR TITLE
Fix: Add network filtering by module and update display logic

### DIFF
--- a/discord/interactions/addConfigCommand.ts
+++ b/discord/interactions/addConfigCommand.ts
@@ -143,13 +143,19 @@ const handleBackToModule = async (
   client: Client,
   restClient: REST
 ) => {
+  const currentConfig = ongoingConfigurationsCache[interaction.guildId!];
+  const network = currentConfig?.network;
+  
   const modulesOptions: SelectMenuComponentOptionData[] = [];
   for (const starkyModuleId in starkyModules) {
     const starkyModule = starkyModules[starkyModuleId];
-    modulesOptions.push({
-      label: starkyModule.name,
-      value: starkyModuleId,
-    });
+    // Only show modules that support the selected network
+    if (network && starkyModule.networks && starkyModule.networks.includes(network)) {
+      modulesOptions.push({
+        label: starkyModule.name,
+        value: starkyModuleId,
+      });
+    }
   }
 
   const selectRow =
@@ -458,10 +464,13 @@ export const handleNetworkConfigCommand = async (
   const modulesOptions: SelectMenuComponentOptionData[] = [];
   for (const starkyModuleId in starkyModules) {
     const starkyModule = starkyModules[starkyModuleId];
-    modulesOptions.push({
-      label: starkyModule.name,
-      value: starkyModuleId,
-    });
+    // Only show modules that support the selected network
+    if (starkyModule.networks && starkyModule.networks.includes(network)) {
+      modulesOptions.push({
+        label: starkyModule.name,
+        value: starkyModuleId,
+      });
+    }
   }
 
   const selectRow =

--- a/starkyModules/erc20.ts
+++ b/starkyModules/erc20.ts
@@ -8,6 +8,7 @@ import { uint256 } from "starknet";
 export const name = "ERC20";
 export const refreshInCron = false;
 export const refreshOnTransfer = true;
+export const networks = ["mainnet", "sepolia"];
 
 export const fields: StarkyModuleField[] = [
   {

--- a/starkyModules/erc721.ts
+++ b/starkyModules/erc721.ts
@@ -7,6 +7,7 @@ import { callContract } from "../utils/starknet/call";
 export const name = "ERC-721";
 export const refreshInCron = false;
 export const refreshOnTransfer = true;
+export const networks = ["mainnet", "sepolia", "ethereum-mainnet"];
 
 export const fields: StarkyModuleField[] = [
   {

--- a/starkyModules/erc721Metadata.ts
+++ b/starkyModules/erc721Metadata.ts
@@ -4,6 +4,7 @@ import { retrieveAssets } from "../utils/retrieveAsset";
 export const name = "ERC-721 Metadata";
 export const refreshInCron = false;
 export const refreshOnTransfer = true;
+export const networks = ["mainnet", "sepolia"];
 
 export const fields: StarkyModuleField[] = [
   {

--- a/starkyModules/walletDetector.ts
+++ b/starkyModules/walletDetector.ts
@@ -8,6 +8,7 @@ export const name = "Wallet detector (Argent only)";
 // Only refreshing when connecting the wallet or when using the /starky-refresh command
 export const refreshInCron = false;
 export const refreshOnTransfer = false;
+export const networks = ["mainnet", "sepolia"];
 
 // TODO => add field to ask for Argent or Braavos
 // we need to be able to validate config first

--- a/types/starkyModules.ts
+++ b/types/starkyModules.ts
@@ -20,6 +20,7 @@ export type StarkyModule = {
   shouldHaveRole: ShouldHaveRole;
   refreshInCron: boolean;
   refreshOnTransfer: boolean;
+  networks: string[];
 };
 
 export type StarkyModules = {


### PR DESCRIPTION
Closes #215 

- [x]  Added networks export to each module
- [x] Modified StarkyModule type in types/starkyModules.ts to include networks: string[] property
- [x] `handleNetworkConfigCommand` now filters modules when a network is selected, only showing modules that support the chosen network
- [x] `handleBackToModule` now filters modules when going back to module selection, using the cached network configuration